### PR TITLE
Add common use case for creating instances with ssh keypair access in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,34 @@ shade
 Example Playbook
 ----------------
 
+Raw role inclusion
+
 ```
 - hosts: openstack_provision-servers
   roles:
     - role: openstack_provision
 ```
+
+Role inclusion with network access to created instances through SSH
+
+```
+- hosts: openstack_provision-servers
+  roles:
+    - role: openstack_provision
+      openstack_provision_servers:
+        - name: test_server
+          flavor: m3.medium
+          image: 'CentOS-7-x86_64-GenericCloud-released-latest'
+          count: 2
+          key: path/to/your/private/key.pem
+          key_name: <name of your ssh keypair>
+          security_groups:
+            - <name of security group you want to use>
+          groups:
+            - test_group
+```
+
+**Note: The local private key should have read/write access for the user group only. This can be achieved with `sudo chmod 600 <keyname>.pem`**
 
 License
 -------


### PR DESCRIPTION
Resolves Issue #1 by adding an example playbook in README.md that configures the role with a security group and SSH keypair for network access to the created instances