### PR TITLE
Force-set name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: openstack_provision
   author: Greg Hellings
   description: Provisions OpenStack hosts and adds them to inventory groups
   company: Red Hat, Inc.


### PR DESCRIPTION
When the role was first imported, its name was open_stack_provision,
which is still reflected in Ansible Galaxy. Fix that.

Fixes #4